### PR TITLE
Remove delegate @synthesize, and rather mask the property from the super class with the new type.

### DIFF
--- a/WSMorseGestureRecognizer/WSMorseGestureRecognizer.m
+++ b/WSMorseGestureRecognizer/WSMorseGestureRecognizer.m
@@ -38,8 +38,6 @@ static const NSTimeInterval kDefaultWordParseDelayInterval = 1.5;
 
 @implementation WSMorseGestureRecognizer
 
-@synthesize delegate;
-
 - (instancetype)initWithTarget:(id)target action:(SEL)action {
     if (self = [super initWithTarget:target action:action]) {
         _letterHistory = @"";


### PR DESCRIPTION
This prevented the default UIGestureRecognizer delegate methods from being called, as the super delegate was never being set.
